### PR TITLE
Use ns-resolve instead of resolve

### DIFF
--- a/src/skyscraper.clj
+++ b/src/skyscraper.clj
@@ -146,14 +146,14 @@
   "Lazily concatenates a sequence-of-sequences into a flat sequence."
   [s]
   (lazy-seq
-   (when-let [s (seq s)] 
+   (when-let [s (seq s)]
      (concat (first s) (join (rest s))))))
 
 (defn do-scrape
   [data params]
   (join (map (fn [x]
                (if-let [processor-key (:processor x)]
-                 (let [proc (resolve (symbol (name processor-key)))
+                 (let [proc (ns-resolve (symbol (or (namespace processor-key) (str *ns*))) (symbol (name processor-key)))
                        input-context (dissoc x :processor)
                        res (unchunk (proc input-context params))
                        res (map (partial into input-context) res)]


### PR DESCRIPTION
This PR is pretty small modification.

The problem is as follows.

```
(ns ex.proc
  (:require [net.cgrand.enlive-html :as html]
            [skyscraper :as s]))

(s/defprocessor root-page
  :cache-template "/ex"
  :process-fn (fn [res ctx]
                (let [child [html/select res [:a#child]]]
                  [{:url (s/href child)
                    :processor ::child-page}])))

(s/defprocessor child-page
  ;; somecode
  )

(ns ex.core
  (:require [skyscraper :as s]))

(def seed [{:url "http://example.com/"
            :processor :ex.proc/root-page}])

(s/scrape seed) ;; does not working, because `do-scrape` function can't resolve different namespace vars.
```

Thank you,
-- ayato-p
