### PR TITLE
Fixed conditional expression order in ensure-seq

### DIFF
--- a/src/skyscraper.clj
+++ b/src/skyscraper.clj
@@ -102,7 +102,7 @@
 (defn ensure-seq
   "Returns the argument verbatim if it's a map. Otherwise, wraps it in a vector."
   [x]
-  (if (map? x) [x] x))
+  (if (map? x) x [x]))
 
 (defn sanitize-cache
   "Converts a cache argument to the processor to a CacheBackend if it


### PR DESCRIPTION
Shouldn't it be reversed? ^.^ According do docstring it should.
